### PR TITLE
feat!: form fields

### DIFF
--- a/src/PowerPlaywright.Framework/Controls/Platform/IFormField.cs
+++ b/src/PowerPlaywright.Framework/Controls/Platform/IFormField.cs
@@ -1,0 +1,29 @@
+﻿namespace PowerPlaywright.Framework.Controls.Platform
+{
+    using PowerPlaywright.Framework.Controls.Platform.Attributes;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// A form field.
+    /// </summary>
+    [PlatformControl]
+    public interface IFormField : IControl
+    {
+        /// <summary>
+        /// Gets the name for the control.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// Gets whether the control is visible.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task<bool> IsVisibleAsync();
+
+        /// <summary>
+        /// Gets the label.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task<string> GetLabelAsync();
+    }
+}

--- a/src/PowerPlaywright.Framework/Controls/Platform/IFormField{TPcfControl}.cs
+++ b/src/PowerPlaywright.Framework/Controls/Platform/IFormField{TPcfControl}.cs
@@ -1,0 +1,19 @@
+﻿namespace PowerPlaywright.Framework.Controls.Platform
+{
+    using PowerPlaywright.Framework.Controls.Pcf;
+    using PowerPlaywright.Framework.Controls.Platform.Attributes;
+
+    /// <summary>
+    /// A form field with a known PCF control type.
+    /// </summary>
+    /// <typeparam name="TPcfControl">The type of the field's control.</typeparam>
+    [PlatformControl]
+    public interface IFormField<out TPcfControl> : IFormField
+        where TPcfControl : IPcfControl
+    {
+        /// <summary>
+        /// Gets the PCF control.
+        /// </summary>
+        TPcfControl Control { get; }
+    }
+}

--- a/src/PowerPlaywright.Framework/Controls/Platform/IMainForm.cs
+++ b/src/PowerPlaywright.Framework/Controls/Platform/IMainForm.cs
@@ -8,7 +8,7 @@
     /// An interface representing a form.
     /// </summary>
     [PlatformControl]
-    public interface IMainFormControl : IPlatformControl
+    public interface IMainForm : IPlatformControl
     {
         /// <summary>
         /// Opens a tab on the form.
@@ -24,12 +24,19 @@
         Task<string> GetActiveTabAsync();
 
         /// <summary>
-        /// Gets a control on the form.
+        /// Gets a field on the form.
         /// </summary>
-        /// <typeparam name="TControl">The control type.</typeparam>
         /// <param name="name">The control name.</param>
         /// <returns>The control.</returns>
-        TControl GetControl<TControl>(string name)
-            where TControl : IPcfControl;
+        IFormField GetField(string name);
+
+        /// <summary>
+        /// Gets a field on the form with a known PCF control or control class type.
+        /// </summary>
+        /// <typeparam name="TPcfControl">The PCF control type.</typeparam>
+        /// <param name="name">The control name.</param>
+        /// <returns>The control.</returns>
+        IFormField<TPcfControl> GetField<TPcfControl>(string name)
+            where TPcfControl : IPcfControl;
     }
 }

--- a/src/PowerPlaywright.Framework/Controls/Platform/ISiteMap.cs
+++ b/src/PowerPlaywright.Framework/Controls/Platform/ISiteMap.cs
@@ -8,7 +8,7 @@
     /// An interface representing a sitemap.
     /// </summary>
     [PlatformControl]
-    public interface ISiteMapControl : IPlatformControl
+    public interface ISiteMap : IPlatformControl
     {
         /// <summary>
         /// Opens a page.

--- a/src/PowerPlaywright.Framework/Pages/IEntityRecordPage.cs
+++ b/src/PowerPlaywright.Framework/Pages/IEntityRecordPage.cs
@@ -10,6 +10,6 @@
         /// <summary>
         /// Gets the form.
         /// </summary>
-        IMainFormControl Form { get; }
+        IMainForm Form { get; }
     }
 }

--- a/src/PowerPlaywright.Framework/Pages/IModelDrivenAppPage.cs
+++ b/src/PowerPlaywright.Framework/Pages/IModelDrivenAppPage.cs
@@ -10,7 +10,7 @@
         /// <summary>
         /// Gets the site map control.
         /// </summary>
-        ISiteMapControl SiteMap { get; }
+        ISiteMap SiteMap { get; }
 
         /// <summary>
         /// Gets an object that provides client API functionality.

--- a/src/PowerPlaywright.Strategies/Controls/Platform/FormField.cs
+++ b/src/PowerPlaywright.Strategies/Controls/Platform/FormField.cs
@@ -1,0 +1,74 @@
+﻿namespace PowerPlaywright.Strategies.Controls.Platform
+{
+    using Microsoft.Playwright;
+    using PowerPlaywright.Framework.Controls;
+    using PowerPlaywright.Framework.Controls.Platform;
+    using PowerPlaywright.Framework.Controls.Platform.Attributes;
+    using PowerPlaywright.Framework.Extensions;
+    using PowerPlaywright.Framework.Pages;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// A strategy for form fields.
+    /// </summary>
+    [PlatformControlStrategy(0, 0, 0, 0)]
+    public class FormField : Control, IFormField
+    {
+        private readonly string name;
+
+        private readonly ILocator label;
+        private readonly ILocator dataSetHostContainer;
+        private readonly ILocator dataSetLabel;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FormField{TControl}"/> class.
+        /// </summary>
+        /// <param name="appPage">The app page.</param>
+        /// <param name="name">The control name.</param>
+        /// <param name="parent">The parent control.</param>
+        public FormField(IAppPage appPage, string name, IControl parent = null)
+            : base(appPage, parent)
+        {
+            this.name = name;
+
+            this.label = this.Container.Locator("label[id*='field-label']");
+            this.dataSetHostContainer = this.Container.Locator("div[data-id='DataSetHostContainer']");
+            this.dataSetLabel = this.dataSetHostContainer.Locator("h3");
+        }
+
+        /// <inheritdoc/>
+        public async Task<string> GetLabelAsync()
+        {
+            await this.AppPage.Page.WaitForAppIdleAsync();
+
+            if (await this.label.IsVisibleAsync())
+            {
+                return await this.label.InnerTextAsync();
+            }
+
+            if (await this.dataSetLabel.IsVisibleAsync())
+            {
+                return await this.label.InnerTextAsync();
+            }
+
+            return string.Empty;
+        }
+
+        /// <inheritdoc/>
+        public string Name => this.name;
+
+        /// <inheritdoc/>
+        public async Task<bool> IsVisibleAsync()
+        {
+            await this.AppPage.Page.WaitForAppIdleAsync();
+
+            return await this.Container.IsVisibleAsync();
+        }
+
+        /// <inheritdoc/>
+        protected override ILocator GetRoot(ILocator context)
+        {
+            return context.Locator($"div[data-control-name='{this.name}']");
+        }
+    }
+}

--- a/src/PowerPlaywright.Strategies/Controls/Platform/FormField{TPcfControl}.cs
+++ b/src/PowerPlaywright.Strategies/Controls/Platform/FormField{TPcfControl}.cs
@@ -1,0 +1,64 @@
+﻿namespace PowerPlaywright.Strategies.Controls.Platform
+{
+    using Microsoft.Playwright;
+    using PowerPlaywright.Framework;
+    using PowerPlaywright.Framework.Controls;
+    using PowerPlaywright.Framework.Controls.Pcf;
+    using PowerPlaywright.Framework.Controls.Platform;
+    using PowerPlaywright.Framework.Controls.Platform.Attributes;
+    using PowerPlaywright.Framework.Pages;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// A strategy for form fields.
+    /// </summary>
+    /// <typeparam name="TPcfControl">The PCF control type.</typeparam>
+    [PlatformControlStrategy(0, 0, 0, 0)]
+    public class FormField<TPcfControl> : Control, IFormField<TPcfControl>
+        where TPcfControl : class, IPcfControl
+    {
+        private readonly IControlFactory controlFactory;
+        private readonly IFormField formField;
+
+        private readonly TPcfControl control;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FormField{TControl}"/> class.
+        /// </summary>
+        /// <param name="appPage">The app page.</param>
+        /// <param name="controlFactory">The control factory.</param>
+        /// <param name="name">The control name.</param>
+        /// <param name="parent">The parent control.</param>
+        public FormField(IControlFactory controlFactory, IAppPage appPage, string name, IControl parent = null)
+            : base(appPage, parent)
+        {
+            this.controlFactory = controlFactory;
+            this.formField = this.controlFactory.CreateInstance<IFormField>(this.AppPage, name, parent);
+            this.control = this.controlFactory.CreateInstance<TPcfControl>(this.AppPage, name, this);
+        }
+
+        /// <inheritdoc/>
+        public TPcfControl Control => this.control;
+
+        /// <inheritdoc/>
+        public Task<string> GetLabelAsync()
+        {
+            return this.formField.GetLabelAsync();
+        }
+
+        /// <inheritdoc/>
+        public string Name => this.formField.Name;
+
+        /// <inheritdoc/>
+        public Task<bool> IsVisibleAsync()
+        {
+            return this.formField.IsVisibleAsync();
+        }
+
+        /// <inheritdoc/>
+        protected override ILocator GetRoot(ILocator context)
+        {
+            return this.formField.Container;
+        }
+    }
+}

--- a/src/PowerPlaywright.Strategies/Controls/Platform/MainForm.cs
+++ b/src/PowerPlaywright.Strategies/Controls/Platform/MainForm.cs
@@ -15,7 +15,7 @@
     /// A main form.
     /// </summary>
     [PlatformControlStrategy(0, 0, 0, 0)]
-    public class MainFormControl : Control, IMainFormControl
+    public class MainForm : Control, IMainForm
     {
         private const string RootLocator = "div[data-id='editFormRoot']";
         private readonly IControlFactory controlFactory;
@@ -23,11 +23,11 @@
         private readonly ILocator tabList;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="MainFormControl"/> class.
+        /// Initializes a new instance of the <see cref="MainForm"/> class.
         /// </summary>
         /// <param name="appPage">The page.</param>
         /// <param name="controlFactory">The control factory.</param>
-        public MainFormControl(IAppPage appPage, IControlFactory controlFactory)
+        public MainForm(IAppPage appPage, IControlFactory controlFactory)
             : base(appPage)
         {
             this.controlFactory = controlFactory ?? throw new ArgumentNullException(nameof(controlFactory));
@@ -42,17 +42,23 @@
         }
 
         /// <inheritdoc/>
+        public IFormField GetField(string name)
+        {
+            return this.controlFactory.CreateInstance<IFormField>(this.AppPage, name, this);
+        }
+
+        /// <inheritdoc/>
+        public IFormField<TControl> GetField<TControl>(string name)
+            where TControl : IPcfControl
+        {
+            return this.controlFactory.CreateInstance<IFormField<TControl>>(this.AppPage, name, this);
+        }
+
+        /// <inheritdoc/>
         public async Task OpenTabAsync(string label)
         {
             await this.tabList.GetByRole(AriaRole.Tab, new LocatorGetByRoleOptions { Name = label }).ClickAsync();
             await this.Page.WaitForAppIdleAsync();
-        }
-
-        /// <inheritdoc/>
-        public TControl GetControl<TControl>(string name)
-            where TControl : IPcfControl
-        {
-            return this.controlFactory.CreateInstance<TControl>(this.AppPage, name, this);
         }
 
         /// <inheritdoc/>

--- a/src/PowerPlaywright.Strategies/Controls/Platform/SiteMap.cs
+++ b/src/PowerPlaywright.Strategies/Controls/Platform/SiteMap.cs
@@ -13,7 +13,7 @@
     /// A sitemap control.
     /// </summary>
     [PlatformControlStrategy(0, 0, 0, 0)]
-    public class SiteMapControl : Control, ISiteMapControl
+    public class SiteMap : Control, ISiteMap
     {
         private const string RootLocator = "div[data-id='navbar-container']";
         private const string AreaSwitcherLocator = "#areaSwitcherId";
@@ -25,11 +25,11 @@
         private readonly ILocator areaSwitcherFlyout;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SiteMapControl"/> class.
+        /// Initializes a new instance of the <see cref="SiteMap"/> class.
         /// </summary>
         /// <param name="appPage">The app page.</param>
         /// <param name="pageFactory">The page factory.</param>
-        public SiteMapControl(IAppPage appPage, IPageFactory pageFactory)
+        public SiteMap(IAppPage appPage, IPageFactory pageFactory)
             : base(appPage)
         {
             this.pageFactory = pageFactory;

--- a/src/PowerPlaywright/ControlFactory.cs
+++ b/src/PowerPlaywright/ControlFactory.cs
@@ -203,7 +203,10 @@
 
         private Type GetStrategyType(Type controlType)
         {
-            if (!this.StrategyMap.TryGetValue(controlType, out var strategyType))
+            var key = controlType.IsConstructedGenericType ?
+                controlType.GetGenericTypeDefinition() : controlType;
+
+            if (!this.StrategyMap.TryGetValue(key, out var strategyType))
             {
                 throw new PowerPlaywrightException($"Type {controlType.Name} is not a valid control interface type.");
             }
@@ -211,6 +214,11 @@
             if (strategyType is null)
             {
                 throw new PowerPlaywrightException($"Unable to find a control strategy for type {controlType.Name}.");
+            }
+
+            if (strategyType.IsGenericTypeDefinition)
+            {
+                strategyType = strategyType.MakeGenericType(controlType.GenericTypeArguments);
             }
 
             return strategyType;

--- a/src/PowerPlaywright/Pages/EntityRecordPage.cs
+++ b/src/PowerPlaywright/Pages/EntityRecordPage.cs
@@ -21,6 +21,6 @@
         }
 
         /// <inheritdoc/>
-        public IMainFormControl Form => this.GetControl<IMainFormControl>();
+        public IMainForm Form => this.GetControl<IMainForm>();
     }
 }

--- a/src/PowerPlaywright/Pages/ModelDrivenAppPage.cs
+++ b/src/PowerPlaywright/Pages/ModelDrivenAppPage.cs
@@ -21,7 +21,7 @@ namespace PowerPlaywright.Pages
         }
 
         /// <inheritdoc/>
-        public ISiteMapControl SiteMap => this.GetControl<ISiteMapControl>();
+        public ISiteMap SiteMap => this.GetControl<ISiteMap>();
 
         /// <inheritdoc/>
         public IClientApi ClientApi => this.GetControl<IClientApi>();

--- a/src/PowerPlaywright/Resolvers/PlatformControlStrategyResolver.cs
+++ b/src/PowerPlaywright/Resolvers/PlatformControlStrategyResolver.cs
@@ -55,7 +55,26 @@
             if (controlType.GetCustomAttribute<PlatformControlAttribute>() is PlatformControlAttribute control)
             {
                 return strategyTypes
-                    .Where(s => controlType.IsAssignableFrom(s) && !s.IsAbstract && s.IsClass && s.IsVisible)
+                    .Where(s =>
+                    {
+                        if (s.IsAbstract || !s.IsClass || !s.IsVisible)
+                        {
+                            return false;
+                        }
+
+
+                        if (controlType.IsAssignableFrom(s))
+                        {
+                            return true;
+                        }
+
+                        if (controlType.IsGenericTypeDefinition)
+                        {
+                            return s.GetInterfaces().Any(i => i.IsConstructedGenericType && i.GetGenericTypeDefinition() == controlType);
+                        }
+
+                        return false;
+                    })
                     .Select(s =>
                         new
                         {

--- a/tests/PowerPlaywright.IntegrationTests/Controls/Pcf/ICustomControlTests.cs
+++ b/tests/PowerPlaywright.IntegrationTests/Controls/Pcf/ICustomControlTests.cs
@@ -42,7 +42,7 @@
 
             var recordPage = await this.LoginAndNavigateToRecordAsync(faker.Generate());
 
-            return recordPage.Form.GetControl<ICustomControlClass>(pp_Record.Forms.Information.Toggle);
+            return recordPage.Form.GetField<ICustomControlClass>(pp_Record.Forms.Information.Toggle).Control;
         }
     }
 }

--- a/tests/PowerPlaywright.IntegrationTests/Controls/Pcf/ILookupTests.cs
+++ b/tests/PowerPlaywright.IntegrationTests/Controls/Pcf/ILookupTests.cs
@@ -105,7 +105,7 @@
 
             var recordPage = await this.LoginAndNavigateToRecordAsync(withRecord.Generate());
 
-            return recordPage.Form.GetControl<ILookup>(pp_Record.Forms.Information.RelatedRecord);
+            return recordPage.Form.GetField<ILookup>(pp_Record.Forms.Information.RelatedRecord).Control;
         }
 
         private Faker<pp_RelatedRecord> GetNamedRelatedRecordFaker(out string relatedRecordName)

--- a/tests/PowerPlaywright.IntegrationTests/Controls/Pcf/IReadOnlyGridTests.cs
+++ b/tests/PowerPlaywright.IntegrationTests/Controls/Pcf/IReadOnlyGridTests.cs
@@ -64,7 +64,7 @@
 
             var recordPage = await this.LoginAndNavigateToRecordAsync(withRecord.Generate());
 
-            return recordPage.Form.GetControl<IReadOnlyGrid>(pp_Record.Forms.Information.RelatedRecordsSubgrid);
+            return recordPage.Form.GetField<IReadOnlyGrid>(pp_Record.Forms.Information.RelatedRecordsSubgrid).Control;
         }
     }
 }

--- a/tests/PowerPlaywright.IntegrationTests/Controls/Pcf/ISingleLineEmailTests.cs
+++ b/tests/PowerPlaywright.IntegrationTests/Controls/Pcf/ISingleLineEmailTests.cs
@@ -62,7 +62,7 @@
 
             var recordPage = await this.LoginAndNavigateToRecordAsync(record.Generate());
 
-            return recordPage.Form.GetControl<ISingleLineEmail>(nameof(pp_Record.pp_singlelineoftextemail));
+            return recordPage.Form.GetField<ISingleLineEmail>(nameof(pp_Record.pp_singlelineoftextemail)).Control;
         }
     }
 }

--- a/tests/PowerPlaywright.IntegrationTests/Controls/Pcf/ISingleLinePhoneNumberTests.cs
+++ b/tests/PowerPlaywright.IntegrationTests/Controls/Pcf/ISingleLinePhoneNumberTests.cs
@@ -62,7 +62,7 @@
 
             var recordPage = await this.LoginAndNavigateToRecordAsync(record.Generate());
 
-            return recordPage.Form.GetControl<ISingleLinePhoneNumber>(nameof(pp_Record.pp_singlelineoftextphonenumber));
+            return recordPage.Form.GetField<ISingleLinePhoneNumber>(nameof(pp_Record.pp_singlelineoftextphonenumber)).Control;
         }
     }
 }

--- a/tests/PowerPlaywright.IntegrationTests/Controls/Pcf/ISingleLineTickerSymbolTests.cs
+++ b/tests/PowerPlaywright.IntegrationTests/Controls/Pcf/ISingleLineTickerSymbolTests.cs
@@ -61,7 +61,7 @@
 
             var recordPage = await this.LoginAndNavigateToRecordAsync(record.Generate());
 
-            return recordPage.Form.GetControl<ISingleLineTickerSymbol>(nameof(pp_Record.pp_singlelineoftexttickersymbol));
+            return recordPage.Form.GetField<ISingleLineTickerSymbol>(nameof(pp_Record.pp_singlelineoftexttickersymbol)).Control;
         }
     }
 }

--- a/tests/PowerPlaywright.IntegrationTests/Controls/Pcf/ISingleLineUrlTests.cs
+++ b/tests/PowerPlaywright.IntegrationTests/Controls/Pcf/ISingleLineUrlTests.cs
@@ -62,7 +62,7 @@
 
             var recordPage = await this.LoginAndNavigateToRecordAsync(record.Generate());
 
-            return recordPage.Form.GetControl<ISingleLineUrl>(nameof(pp_Record.pp_singlelineoftexturl));
+            return recordPage.Form.GetField<ISingleLineUrl>(nameof(pp_Record.pp_singlelineoftexturl)).Control;
         }
     }
 }

--- a/tests/PowerPlaywright.IntegrationTests/Controls/Platform/IFormFieldTests.cs
+++ b/tests/PowerPlaywright.IntegrationTests/Controls/Platform/IFormFieldTests.cs
@@ -1,0 +1,94 @@
+﻿namespace PowerPlaywright.IntegrationTests.Controls.Pcf
+{
+    using System.Threading.Tasks;
+    using Bogus;
+    using PowerPlaywright.Framework.Controls.Pcf;
+    using PowerPlaywright.Framework.Controls.Pcf.Classes;
+    using PowerPlaywright.Framework.Controls.Platform;
+    using PowerPlaywright.TestApp.Model;
+    using PowerPlaywright.TestApp.Model.Fakers;
+
+    /// <summary>
+    /// Tests the <see cref="IFormField{TPcfControl}"/> and <see cref="IFormField"/> platform controls.
+    /// </summary>
+    public class IFormFieldTests : IntegrationTests
+    {
+        /// <summary>
+        /// Tests that the <see cref="IFormField{TPcfControl}.Control"/> property returns an instance of the PCF control type.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Test]
+        public async Task PcfControl_Always_ReturnsPcfControlInstance()
+        {
+            var form = await this.SetupFormScenarioAsync();
+            var control = form.GetField<ISingleLineUrl>(nameof(pp_Record.pp_singlelineoftexturl));
+
+            Assert.That(control.Control, Is.Not.Null);
+        }
+
+        /// <summary>
+        /// Tests that <see cref="IFormField.IsVisibleAsync"/> returns true if the control is visible.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Test]
+        public async Task IsVisibleAsync_ControlIsVisible_ReturnsTrue()
+        {
+            var form = await this.SetupFormScenarioAsync();
+            var control = form.GetField(nameof(pp_Record.pp_singlelineoftexturl));
+
+            Assert.That(control.IsVisibleAsync, Is.True);
+        }
+
+        /// <summary>
+        /// Tests that <see cref="IFormField.IsVisibleAsync"/> returns false if the control is hidden.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        [Test]
+        public async Task IsVisibleAsync_ControlIsHidden_ReturnsFalse()
+        {
+            var form = await this.SetupFormScenarioAsync();
+            var control = form.GetField(nameof(pp_Record.pp_singlelineoftexturl));
+
+            Assert.That(control.IsVisibleAsync, Is.True);
+        }
+
+        /// <summary>
+        /// Tests that <see cref="IFormField.GetLabelAsync"/> returns the label text if the label is visible.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Test]
+        public async Task GetLabelAsync_LabelIsVisible_ReturnsLabelText()
+        {
+            var form = await this.SetupFormScenarioAsync();
+            var control = form.GetField(nameof(pp_Record.pp_singlelineoftexturl));
+
+            Assert.That(control.GetLabelAsync, Is.EqualTo("Single line of text (URL)"));
+        }
+
+        /// <summary>
+        /// Tests that <see cref="IFormField.GetLabelAsync"/> returns an empty string if the label is hidden.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Test]
+        public async Task GetLabelAsync_LabelIsHidden_ReturnsEmptyString()
+        {
+            var form = await this.SetupFormScenarioAsync();
+            var control = form.GetField(pp_Record.Forms.Information.RelatedRecordsSubgrid);
+
+            Assert.That(control.GetLabelAsync, Is.Empty);
+        }
+
+        /// <summary>
+        /// Sets up a form scenario.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation. The task result contains the initialized <see cref="IUrlControl"/>.</returns>
+        private async Task<IMainForm> SetupFormScenarioAsync()
+        {
+            var record = new RecordFaker();
+
+            var recordPage = await this.LoginAndNavigateToRecordAsync(record.Generate());
+
+            return recordPage.Form;
+        }
+    }
+}

--- a/tests/PowerPlaywright.IntegrationTests/Controls/Platform/ISiteMapTests.cs
+++ b/tests/PowerPlaywright.IntegrationTests/Controls/Platform/ISiteMapTests.cs
@@ -8,11 +8,11 @@
     using PowerPlaywright.TestApp.Model.App;
 
     /// <summary>
-    /// Tests for the <see cref="SiteMapControl"/> control.
+    /// Tests for the <see cref="SiteMap"/> control.
     /// </summary>
-    public partial class ISiteMapControlTests : IntegrationTests
+    public partial class ISiteMapTests : IntegrationTests
     {
-        private ISiteMapControl siteMapControl;
+        private ISiteMap siteMapControl;
 
         /// <summary>
         /// Sets up the read-only grid.
@@ -25,7 +25,7 @@
         }
 
         /// <summary>
-        /// Tests that <see cref="ISiteMapControl.OpenPageAsync{TPage}(string, string, string)"/> opens a page correctly.
+        /// Tests that <see cref="ISiteMap.OpenPageAsync{TPage}(string, string, string)"/> opens a page correctly.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Test]
@@ -40,7 +40,7 @@
         }
 
         /// <summary>
-        /// Tests that <see cref="ISiteMapControl.OpenPageAsync{TPage}(string, string, string)"/> throws a <see cref="NotFoundException"/> if the page doesn't exist.
+        /// Tests that <see cref="ISiteMap.OpenPageAsync{TPage}(string, string, string)"/> throws a <see cref="NotFoundException"/> if the page doesn't exist.
         /// </summary>
         [Test]
         public void OpenPageAsync_PageDoesNotExist_ThrowsNotFoundException()
@@ -52,7 +52,7 @@
         }
 
         /// <summary>
-        /// Tests that <see cref="ISiteMapControl.OpenPageAsync{TPage}(string, string, string)"/> throws a <see cref="NotFoundException"/> if the group doesn't exist.
+        /// Tests that <see cref="ISiteMap.OpenPageAsync{TPage}(string, string, string)"/> throws a <see cref="NotFoundException"/> if the group doesn't exist.
         /// </summary>
         [Test]
         public void OpenPageAsync_GroupDoesNotExist_ThrowsNotFoundException()
@@ -64,7 +64,7 @@
         }
 
         /// <summary>
-        /// Tests that <see cref="ISiteMapControl.OpenPageAsync{TPage}(string, string, string)"/> throws a <see cref="NotFoundException"/> if the group doesn't exist.
+        /// Tests that <see cref="ISiteMap.OpenPageAsync{TPage}(string, string, string)"/> throws a <see cref="NotFoundException"/> if the group doesn't exist.
         /// </summary>
         [Test]
         public void OpenPageAsync_AreaDoesNotExist_ThrowsNotFoundException()

--- a/tests/PowerPlaywright.UnitTests/Pages/AppPageTests.cs
+++ b/tests/PowerPlaywright.UnitTests/Pages/AppPageTests.cs
@@ -63,7 +63,7 @@ public class AppPageTests : AppPageTests<IAppPage>
     {
         _ = this.AppPage.Form;
 
-        this.ControlFactory.Received(1).CreateInstance<IMainFormControl>(this.AppPage);
+        this.ControlFactory.Received(1).CreateInstance<IMainForm>(this.AppPage);
     }
 
     /// <summary>
@@ -75,7 +75,7 @@ public class AppPageTests : AppPageTests<IAppPage>
         var firstControl = this.AppPage.Form;
         var secondControl = this.AppPage.Form;
 
-        this.ControlFactory.Received(1).CreateInstance<IMainFormControl>(this.AppPage);
+        this.ControlFactory.Received(1).CreateInstance<IMainForm>(this.AppPage);
         Assert.That(firstControl, Is.EqualTo(secondControl));
     }
 

--- a/tests/PowerPlaywright.UnitTests/Pages/EntityRecordPageTests.cs
+++ b/tests/PowerPlaywright.UnitTests/Pages/EntityRecordPageTests.cs
@@ -48,7 +48,7 @@ public class EntityRecordPageTests : AppPageTests<IEntityRecordPage>
     /// <param name="propertyName">The property.</param>
     /// <param name="controlName">The control name (optional).</param>
     [Test]
-    [TestCase<IMainFormControl>(nameof(IEntityRecordPage.Form))]
+    [TestCase<IMainForm>(nameof(IEntityRecordPage.Form))]
     public new void ControlProperty_Always_ReturnsControlInstantiatedByControlFactory<TControlType>(
         string propertyName, string? controlName = null)
         where TControlType : class, IControl

--- a/tests/PowerPlaywright.UnitTests/Pages/ModelDrivenAppPageTests.cs
+++ b/tests/PowerPlaywright.UnitTests/Pages/ModelDrivenAppPageTests.cs
@@ -20,7 +20,7 @@ public class ModelDrivenAppPageTests : AppPageTests<IModelDrivenAppPage>
     /// <param name="propertyName">The property.</param>
     /// <param name="controlName">The control name (optional).</param>
     [Test]
-    [TestCase<ISiteMapControl>(nameof(IModelDrivenAppPage.SiteMap))]
+    [TestCase<ISiteMap>(nameof(IModelDrivenAppPage.SiteMap))]
     [TestCase<IClientApi>(nameof(IModelDrivenAppPage.ClientApi))]
     public new void ControlProperty_Always_ReturnsControlInstantiatedByControlFactory<TControlType>(
         string propertyName, string? controlName = null)

--- a/tests/PowerPlaywright.UnitTests/Resolvers/PlatformControlStrategyResolverTests.cs
+++ b/tests/PowerPlaywright.UnitTests/Resolvers/PlatformControlStrategyResolverTests.cs
@@ -125,7 +125,7 @@ public class PlatformControlStrategyResolverTests
     [Test]
     public void Resolve_NullControlType_ThrowsArgumentNullException()
     {
-        Assert.Throws<ArgumentNullException>(() => this.resolver.Resolve(null, [typeof(SiteMapControl)]));
+        Assert.Throws<ArgumentNullException>(() => this.resolver.Resolve(null, [typeof(SiteMap)]));
     }
 
     /// <summary>


### PR DESCRIPTION
This refactors the main form implementation to return fields instead of PCF controls directly. This enables common functionality to be implemented (e.g. visibility, labels) and shared across all PCF controls - including those that are yet to be implemented.