### PR TITLE
fix: NullReferenceException on calling CreateAsync

### DIFF
--- a/src/PowerPlaywright/Extensions/ServiceCollectionExtensions.cs
+++ b/src/PowerPlaywright/Extensions/ServiceCollectionExtensions.cs
@@ -79,6 +79,11 @@
         /// <returns></returns>
         public static IServiceCollection AddAdditionalPageObjectAssemblies(this IServiceCollection services, IEnumerable<PageObjectAssemblyConfiguration> pageObjectAssemblies)
         {
+            if (pageObjectAssemblies == null)
+            {
+                return services;
+            }
+
             foreach (var pageObjectAssembly in pageObjectAssemblies)
             {
                 services.AddSingleton<IAssemblyProvider>(new LocalAssemblyProvider(pageObjectAssembly.Path));


### PR DESCRIPTION
A `NullReferenceException` is being thrown when no `PageObjectAssemblies` are configured.

Closes #51.