### PR TITLE
fix: unable to click split button commands

### DIFF
--- a/src/PowerPlaywright.Strategies/Controls/Platform/CommandBar.cs
+++ b/src/PowerPlaywright.Strategies/Controls/Platform/CommandBar.cs
@@ -199,7 +199,7 @@
 
         private ILocator GetSplitButtonMainCommand(ILocator command)
         {
-            return command.Locator("[role='button']:not[aria-haspopup='true']");
+            return command.Locator("[role='button']:not([aria-haspopup='true'])");
         }
 
         private ILocator GetSplitButtonDropdownCommand(ILocator command)


### PR DESCRIPTION
A fix to make the split command naming agnostic as some menu ordering will not always be Menu0, it is not reliable to use 0 every time as in a legacy app I am working on it doesnt guarantee that in every command bar so making it a regex may be more stable for consumers. Resolves #124 